### PR TITLE
Warn of the dangers of using this package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # patch_package
 
+> [!CAUTION]
+> This package **will modify** you `PUB_CACHE`, it is strongly adviced that you do **not modify** files in `PUB_CACHE`!
+> 
+> The `PUB_CACHE` is intended to be immutable, and should not be modified by tools other than `dart pub` / `flutter pub`.
+> Modifying files in `PUB_CACHE` can cause unrelated projects and tools to fail unexpectedly, or behave in unintended ways!
+>
+> You can repair you `PUB_CACHE` using [`dart pub cache repair`](https://dart.dev/tools/pub/cmd/pub-cache#reinstalling-all-packages-in-the-system-cache).
+
 Dart tool for patching Flutter packages, enabling quick fixes, modifications, and version control integration for a smoother development workflow.
 
 ##  Features


### PR DESCRIPTION
Correct me, if I'm wrong here, but it looks like this package modifies files in `PUB_CACHE`, is that correct?

----------

Please advise users not to use this package.

Please consider flagging this package as **discontinued** on pub.dev.

Modifying `PUB_CACHE` is bad, users who do this, might not realize that they've poisoned their `PUB_CACHE`. They might have been using `patch_package` on a toy project, and suddenly they'll be using their patches in other unrelated projects because they are stored in `PUB_CACHE`.

They might get weird unexplained behavior months or years later in totally unrelated projects, because files in their `PUB_CACHE` have been modified in arbitrary ways. They'll report bugs that maintainers can't reproduce! They won't be able to reproduce their behavior in CI or on other machines. They might think their their personal computer has a very weird problem with Dart or Flutter, one that nobody else has. If you've forgotten that you've modified your `PUB_CACHE`, it can be really hard to figure out why something is broken.

To be fair: I've certainly used go-to-definition and inserted `print` statements during debugging, and I've also experienced these unexplained prints showing up in logs of another projects weeks later with no explanation -- So I'm by no means perfect :rofl::rofl::rofl:

But I'd still advice against this, and certainly warn people of the dangers!

## You can also change how it works!

You could copy the package to be modified into `.dart_tool/patched-packages/<package>` and then either:
 * Create a `pubspec_overrides.yaml` that specifies a `dependencies_overrides` with a path-dependency on the package in `.dart_tool/patched-packages/<package>`.
 * Use `dependency_overrides` in `pubspec.yaml` to create a path-dependency pointing at `.dart_tool/patched-packages/<package>`.
 * Modify `.dart_tool/package_config.json` to point to `.dart_tool/patched-packages/<package>`
   * **WARNING** This also won't work will, and will probably break various tooling, but at-least you won't be breaking every project / tool on the users computer going forward!

Or do something like `package:vendor`, though it's certainly not a perfect solution.